### PR TITLE
Gather relevant bindings from the LHS of cases in pattern matches

### DIFF
--- a/src/test/resources/pattern-match-on-nested-case-class/expected.txt
+++ b/src/test/resources/pattern-match-on-nested-case-class/expected.txt
@@ -1,0 +1,14 @@
+src/test/resources/pattern-match-on-nested-case-class/input.scala:9:
+Found hole with type: Boolean
+Relevant bindings include
+  c: foo.Child (bound at input.scala:9:32)
+  d: foo.Child (bound at input.scala:9:55)
+  hmm: Int (bound at input.scala:9:42)
+  ok: String (bound at input.scala:9:47)
+  p: foo.Parent (bound at input.scala:9:10)
+  parent: foo.Parent (bound at input.scala:8:11)
+  wow: String (bound at input.scala:9:21)
+  yeah: Int (bound at input.scala:9:26)
+
+    case p @ Parent(wow, yeah, c @ Child(hmm, ok, _), d, Child(_, _, _)) => ???
+                                                                            ^

--- a/src/test/resources/pattern-match-on-nested-case-class/input.scala
+++ b/src/test/resources/pattern-match-on-nested-case-class/input.scala
@@ -1,0 +1,11 @@
+package foo
+
+case class Child(x: Int, y: String, z: Boolean)
+case class Parent(a: String, b: Int, c: Child, d: Child, e: Child)
+
+object Foo {
+
+  def bar(parent: Parent): Boolean = parent match {
+    case p @ Parent(wow, yeah, c @ Child(hmm, ok, _), d, Child(_, _, _)) => ???
+  }
+}


### PR DESCRIPTION
For code such as

```scala
case Foo(a, b, c @ Bar(x, y, z)) => ???
```

the plugin now collects all the bindings from the LHS and displays them in the "relevant bindings" section of the warning message for the hole.