### PR TITLE
#17 Handle cases where type holes are in by name argument closures.

### DIFF
--- a/src/main/scala/holes/TypedHolesPlugin.scala
+++ b/src/main/scala/holes/TypedHolesPlugin.scala
@@ -65,6 +65,9 @@ class TypedHolesComponent(plugin: Plugin, val global: Global, getLogLevel: () =>
     override def traverse(tree: Tree): Unit = {
 
       tree match {
+        case ValDef(_, _, Hole(holeInLhs), tpt) =>
+          log(holeInLhs.pos, tpt.tpe)
+          super.traverse(tree)
         case ValDef(_, _, tpt, Hole(holeInRhs)) =>
           log(holeInRhs.pos, tpt.tpe)
           super.traverse(tree)

--- a/src/main/scala/holes/TypedHolesPlugin.scala
+++ b/src/main/scala/holes/TypedHolesPlugin.scala
@@ -68,6 +68,11 @@ class TypedHolesComponent(plugin: Plugin, val global: Global, getLogLevel: () =>
         case ValDef(_, _, tpt, Hole(holeInRhs)) =>
           log(holeInRhs.pos, tpt.tpe)
           super.traverse(tree)
+        case ValDef(_, _, tpt, Function(vparams, Hole(body))) =>
+          bindings.push(vparams.map(param => (param.name, Binding(param.tpt.tpe, param.pos))).toMap)
+          log(body.pos, tpt.tpe.typeArgs.last)
+          super.traverse(tree)
+          bindings.pop()
         case ValDef(_, _, _, _) =>
           super.traverse(tree)
         case DefDef(_, _, _, vparamss, tpt, Hole(holeInRhs)) =>
@@ -77,15 +82,6 @@ class TypedHolesComponent(plugin: Plugin, val global: Global, getLogLevel: () =>
           bindings.pop()
         case DefDef(_, _, _, vparamss, _, _) =>
           bindings.push(vparamss.flatten.map(param => (param.name, Binding(param.tpt.tpe, param.pos))).toMap)
-          super.traverse(tree)
-          bindings.pop()
-        case Function(vparams, Hole(body)) =>
-          bindings.push(vparams.map(param => (param.name, Binding(param.tpt.tpe, param.pos))).toMap)
-          log(body.pos, tree.tpe.typeArgs.last)
-          super.traverse(tree)
-          bindings.pop()
-        case Function(vparams, _) =>
-          bindings.push(vparams.map(param => (param.name, Binding(param.tpt.tpe, param.pos))).toMap)
           super.traverse(tree)
           bindings.pop()
         case If(_, Hole(a), Hole(b)) =>

--- a/src/test/resources/val-var-def-one-liners/expected.txt
+++ b/src/test/resources/val-var-def-one-liners/expected.txt
@@ -30,7 +30,7 @@ Relevant bindings include
   val hole9 = { x: String => ??? }
                              ^
 src/test/resources/val-var-def-one-liners/input.scala:23:
-Found hole with type: Nothing
+Found hole with type: Int
 Relevant bindings include
   x: String (bound at input.scala:23:33)
 
@@ -45,10 +45,18 @@ Relevant bindings include
   val hole11 = { (a: Int, b: String) => ??? }
                                         ^
 src/test/resources/val-var-def-one-liners/input.scala:27:
-Found hole with type: Nothing
+Found hole with type: Int
 Relevant bindings include
   a: Int (bound at input.scala:27:41)
   b: String (bound at input.scala:27:44)
 
   val hole12: (Int, String) => Int = { (a, b) => ??? }
                                                  ^
+src/test/resources/val-var-def-one-liners/input.scala:29:
+Found hole with type: (String, Int)
+Relevant bindings include
+  a: Int (bound at input.scala:29:51)
+  b: String (bound at input.scala:29:54)
+
+  val hole13: (Int, String) => (String, Int) = { (a, b) => ??? }
+                                                           ^

--- a/src/test/resources/val-var-def-one-liners/expected.txt
+++ b/src/test/resources/val-var-def-one-liners/expected.txt
@@ -16,3 +16,9 @@ src/test/resources/val-var-def-one-liners/input.scala:13: Found hole with type: 
 src/test/resources/val-var-def-one-liners/input.scala:15: Found hole with type: Option[String]
   var hole6: Option[String] = ???
                               ^
+src/test/resources/val-var-def-one-liners/input.scala:17: Found hole with type: Nothing
+  val hole7 = { ??? }
+                ^
+src/test/resources/val-var-def-one-liners/input.scala:19: Found hole with type: () => Int
+  val hole8: () => Int = { ??? }
+                           ^

--- a/src/test/resources/val-var-def-one-liners/expected.txt
+++ b/src/test/resources/val-var-def-one-liners/expected.txt
@@ -60,3 +60,11 @@ Relevant bindings include
 
   val hole13: (Int, String) => (String, Int) = { (a, b) => ??? }
                                                            ^
+src/test/resources/val-var-def-one-liners/input.scala:31:
+Found hole with type: scala.util.Try[Nothing]
+Relevant bindings include
+  i: Int (bound at input.scala:31:87)
+  s: String (bound at input.scala:31:49)
+
+  val hole14: String => scala.util.Try[Int] = { s => scala.util.Try { s.toInt }.map { i => ??? } }
+                                                                                           ^

--- a/src/test/resources/val-var-def-one-liners/expected.txt
+++ b/src/test/resources/val-var-def-one-liners/expected.txt
@@ -61,10 +61,11 @@ Relevant bindings include
   val hole13: (Int, String) => (String, Int) = { (a, b) => ??? }
                                                            ^
 src/test/resources/val-var-def-one-liners/input.scala:31:
-Found hole with type: scala.util.Try[Nothing]
+Found hole with type: Int
 Relevant bindings include
-  i: Int (bound at input.scala:31:87)
-  s: String (bound at input.scala:31:49)
+  a: Int (bound at input.scala:31:55)
+  c: Char (bound at input.scala:31:58)
+  s: String (bound at input.scala:31:33)
 
-  val hole14: String => scala.util.Try[Int] = { s => scala.util.Try { s.toInt }.map { i => ??? } }
-                                                                                           ^
+  val hole14: String => Int = { s => s.foldLeft(0) { (a, c) => ??? } }
+                                                               ^

--- a/src/test/resources/val-var-def-one-liners/expected.txt
+++ b/src/test/resources/val-var-def-one-liners/expected.txt
@@ -22,3 +22,33 @@ src/test/resources/val-var-def-one-liners/input.scala:17: Found hole with type: 
 src/test/resources/val-var-def-one-liners/input.scala:19: Found hole with type: () => Int
   val hole8: () => Int = { ??? }
                            ^
+src/test/resources/val-var-def-one-liners/input.scala:21:
+Found hole with type: Nothing
+Relevant bindings include
+  x: String (bound at input.scala:21:18)
+
+  val hole9 = { x: String => ??? }
+                             ^
+src/test/resources/val-var-def-one-liners/input.scala:23:
+Found hole with type: Nothing
+Relevant bindings include
+  x: String (bound at input.scala:23:33)
+
+  val hole10: String => Int = { x => ??? }
+                                     ^
+src/test/resources/val-var-def-one-liners/input.scala:25:
+Found hole with type: Nothing
+Relevant bindings include
+  a: Int (bound at input.scala:25:20)
+  b: String (bound at input.scala:25:28)
+
+  val hole11 = { (a: Int, b: String) => ??? }
+                                        ^
+src/test/resources/val-var-def-one-liners/input.scala:27:
+Found hole with type: Nothing
+Relevant bindings include
+  a: Int (bound at input.scala:27:41)
+  b: String (bound at input.scala:27:44)
+
+  val hole12: (Int, String) => Int = { (a, b) => ??? }
+                                                 ^

--- a/src/test/resources/val-var-def-one-liners/input.scala
+++ b/src/test/resources/val-var-def-one-liners/input.scala
@@ -26,4 +26,6 @@ object Foo {
 
   val hole12: (Int, String) => Int = { (a, b) => ??? }
 
+  val hole13: (Int, String) => (String, Int) = { (a, b) => ??? }
+
 }

--- a/src/test/resources/val-var-def-one-liners/input.scala
+++ b/src/test/resources/val-var-def-one-liners/input.scala
@@ -28,6 +28,6 @@ object Foo {
 
   val hole13: (Int, String) => (String, Int) = { (a, b) => ??? }
 
-  val hole14: String => scala.util.Try[Int] = { s => scala.util.Try { s.toInt }.map { i => ??? } }
+  val hole14: String => Int = { s => s.foldLeft(0) { (a, c) => ??? } }
 
 }

--- a/src/test/resources/val-var-def-one-liners/input.scala
+++ b/src/test/resources/val-var-def-one-liners/input.scala
@@ -14,4 +14,8 @@ object Foo {
 
   var hole6: Option[String] = ???
 
+  val hole7 = { ??? }
+
+  val hole8: () => Int = { ??? }
+
 }

--- a/src/test/resources/val-var-def-one-liners/input.scala
+++ b/src/test/resources/val-var-def-one-liners/input.scala
@@ -28,4 +28,6 @@ object Foo {
 
   val hole13: (Int, String) => (String, Int) = { (a, b) => ??? }
 
+  val hole14: String => scala.util.Try[Int] = { s => scala.util.Try { s.toInt }.map { i => ??? } }
+
 }

--- a/src/test/resources/val-var-def-one-liners/input.scala
+++ b/src/test/resources/val-var-def-one-liners/input.scala
@@ -18,4 +18,12 @@ object Foo {
 
   val hole8: () => Int = { ??? }
 
+  val hole9 = { x: String => ??? }
+
+  val hole10: String => Int = { x => ??? }
+
+  val hole11 = { (a: Int, b: String) => ??? }
+
+  val hole12: (Int, String) => Int = { (a, b) => ??? }
+
 }


### PR DESCRIPTION
Handle by name argument closures.

This PR is not covering full-fledged function literals like { a: String => ??? }
I'm currently exploring adding them as well.