### PR TITLE
Support holes as function arguments

### DIFF
--- a/src/main/scala/holes/TypedHolesComponent.scala
+++ b/src/main/scala/holes/TypedHolesComponent.scala
@@ -71,11 +71,14 @@ class TypedHolesComponent(plugin: Plugin, val global: Global, getLogLevel: () =>
             case _ =>
           }
           super.traverse(tree)
-        case a @ Apply(_, args) =>
-          args foreach {
-            case Function(vparams, Hole(body)) =>
+        case a @ Apply(fn, args) =>
+          val paramTypes = fn.symbol.paramss.flatten.map(_.tpe)
+          paramTypes.zip(args).foreach {
+            case (paramTpe, Hole(body)) =>
+              log(body, paramTpe)
+            case (paramTpe, Function(vparams, Hole(body))) =>
               bindings.push(vparams.map(param => (param.name, Binding(param.tpt.tpe, param.pos))).toMap)
-              log(body, a.tpe)
+              log(body, paramTpe)
               bindings.pop()
             case _ =>
           }

--- a/src/test/resources/val-var-def-one-liners/expected.txt
+++ b/src/test/resources/val-var-def-one-liners/expected.txt
@@ -61,11 +61,25 @@ Relevant bindings include
   val hole13: (Int, String) => (String, Int) = { (a, b) => ??? }
                                                            ^
 src/test/resources/val-var-def-one-liners/input.scala:31:
-Found hole with type: Int
+Found hole with type: B
 Relevant bindings include
-  a: Int (bound at input.scala:31:55)
-  c: Char (bound at input.scala:31:58)
+  a: Double (bound at input.scala:31:65)
+  c: Char (bound at input.scala:31:68)
   s: String (bound at input.scala:31:33)
 
-  val hole14: String => Int = { s => s.foldLeft(0) { (a, c) => ??? } }
-                                                               ^
+  val hole14: String => Int = { s => s.foldLeft[Double](0.0) { (a, c) => ??? }.toInt }
+                                                                         ^
+src/test/resources/val-var-def-one-liners/input.scala:33:
+Found hole with type: CharSequence
+Relevant bindings include
+  x: String (bound at input.scala:33:14)
+
+  def hole15(x: String) = x.contains(???)
+                                     ^
+src/test/resources/val-var-def-one-liners/input.scala:35:
+Found hole with type: Char => Boolean
+Relevant bindings include
+  x: String (bound at input.scala:35:14)
+
+  def hole16(x: String) = x.exists(???)
+                                   ^

--- a/src/test/resources/val-var-def-one-liners/expected.txt
+++ b/src/test/resources/val-var-def-one-liners/expected.txt
@@ -77,9 +77,9 @@ Relevant bindings include
   def hole15(x: String) = x.contains(???)
                                      ^
 src/test/resources/val-var-def-one-liners/input.scala:35:
-Found hole with type: Char => Boolean
+Found hole with type: A => Boolean
 Relevant bindings include
-  x: String (bound at input.scala:35:14)
+  xs: List[Int] (bound at input.scala:35:14)
 
-  def hole16(x: String) = x.exists(???)
-                                   ^
+  def hole16(xs: List[Int]) = xs.exists(???)
+                                        ^

--- a/src/test/resources/val-var-def-one-liners/input.scala
+++ b/src/test/resources/val-var-def-one-liners/input.scala
@@ -28,6 +28,10 @@ object Foo {
 
   val hole13: (Int, String) => (String, Int) = { (a, b) => ??? }
 
-  val hole14: String => Int = { s => s.foldLeft(0) { (a, c) => ??? } }
+  val hole14: String => Int = { s => s.foldLeft[Double](0.0) { (a, c) => ??? }.toInt }
+
+  def hole15(x: String) = x.contains(???)
+
+  def hole16(x: String) = x.exists(???)
 
 }

--- a/src/test/resources/val-var-def-one-liners/input.scala
+++ b/src/test/resources/val-var-def-one-liners/input.scala
@@ -32,6 +32,6 @@ object Foo {
 
   def hole15(x: String) = x.contains(???)
 
-  def hole16(x: String) = x.exists(???)
+  def hole16(xs: List[Int]) = xs.exists(???)
 
 }


### PR DESCRIPTION
Given `foo.bar(123, "abc", ???)`, we look up the `foo.bar` symbol to get the types of its parameters, which gives us the type of the hole.

Note: there's a big assumption here that the number of params exactly matches the number of args, which is not true in the case of default args, varargs, etc. So this will not catch all cases, but it's a step in the right direction.

Fixes #43 